### PR TITLE
Add node/npm enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+max_line_length = 100
+quote_type = single

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Frontend Code test
 ## Project setup
 ```
+nvm install 14.17
+nvm use
+npm install -g npm@7.19
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "sass-loader": "^8.0.2",
     "style-resources-loader": "^1.4.1",
     "vue-template-compiler": "^2.6.11"
+  },
+  "engines": {
+    "node": "14.17",
+    "npm": "7.19"
   }
 }


### PR DESCRIPTION
Story details: https://app.shortcut.com/dashhudson/story/57093

Enforcement will prevent applicants from having a bad time if their local version of node/npm is not consistent with the environment in which this was developed.

.editorconfig will prevent many annoyances with format on save.